### PR TITLE
fix: unhandledRejection for rejected promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,26 +30,18 @@ module.exports = (stream, opts) => {
 	}
 
 	const completion = new Promise((resolve, reject) => {
-		function onEnd(result) {
-			if (awaited) {
-				awaited.then(resolve);
+		if (awaited) {
+			if (endEvent) {
+				awaited.catch(reject);
 			} else {
-				resolve(result);
+				awaited.then(resolve, reject);
 			}
-		}
-
-		if (endEvent) {
-			stream.once(endEvent, onEnd);
-		} else if (awaited) {
-			onEnd();
+		} else if (endEvent) {
+			stream.once(endEvent, resolve);
 		}
 
 		if (errorEvent) {
 			stream.once(errorEvent, reject);
-		}
-
-		if (awaited) {
-			awaited.catch(reject);
 		}
 	}).catch(err => {
 		cleanup();

--- a/test.js
+++ b/test.js
@@ -68,6 +68,18 @@ test(`${prefix}: forEach resolves after resolution of the awaited promise`, asyn
 	t.is(result, undefined);
 });
 
+test(`${prefix}: handles the rejected promise correctly`, async t => {
+	t.plan(1);
+	const ee = new EventEmitter();
+	const awaited = Promise.reject(new Error('rejection'));
+
+	await t.throws(
+		m(ee, {endEvent: false, await: awaited}),
+		'rejection'
+	);
+	// And should not emit an unhandledRejection event
+});
+
 test(`${prefix}: rejects on error events`, async t => {
 	t.plan(3);
 


### PR DESCRIPTION
Fixes https://github.com/jamestalmage/stream-to-observable/issues/12

Currently, this emits unhandledRejection event and throws UnhandledPromiseRejectionWarning when the awaited promise is rejected.
This PR fixes to handle the rejected promise correctly.

Also I sent same PR to origin: https://github.com/jamestalmage/stream-to-observable/pull/13