### PR TITLE
Add missing optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,14 @@
 	"dependencies": {
 		"any-observable": "^0.3.0"
 	},
+	"peerDependenciesMeta": {
+		"rxjs": {
+			optional: true
+		},
+		"zen-observable": {
+			optional: true
+		}
+	},
 	"devDependencies": {
 		"array-to-events": "^1.0.0",
 		"ava": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
 	},
 	"peerDependenciesMeta": {
 		"rxjs": {
-			optional: true
+			"optional": true
 		},
 		"zen-observable": {
-			optional: true
+			"optional": true
 		}
 	},
 	"devDependencies": {


### PR DESCRIPTION
This diff adds the missing **optional** peer dependencies on `rxjs` and `zen-observable` (required because of the transitive dependency on `any-observable`, cf https://github.com/sindresorhus/any-observable/pull/25). Without that, Yarn will refuse giving `any-observable` access to the Observable implementations.

Because it only uses `peerDependenciesMeta` (and not `peerDependencies`), this diff is entirely compatible with other package managers (it won't cause warning to appear anywhere).